### PR TITLE
Update ParticleSystemControlMixer.cs

### DIFF
--- a/Assets/ParticleSystemControl/Runtime/ParticleSystemControlMixer.cs
+++ b/Assets/ParticleSystemControl/Runtime/ParticleSystemControlMixer.cs
@@ -191,6 +191,14 @@ public class ParticleSystemControlMixer : PlayableBehaviour
             }
         }
     }
+    
+    public override void OnGraphStop(Playable playable)
+    {
+        if (particleSystem == null) return;
+
+        if (Application.isPlaying)
+            particleSystem.Stop();
+    }
 
     #endregion
 }


### PR DESCRIPTION
Added an override to OnGraphStop() so the particle would stop emitting when the timeline stops midplay.
This is useful in my case because I'm using timelines as states, and not always would wait till the timeline ends, so the particle system from the previous timeline/state still played through.